### PR TITLE
Support RN56: Use compileSdkVersion & buildToolsVersion from project if set

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 23
+    buildToolsVersion buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : "23.0.1"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Fixes 
  > The SDK Build Tools revision (23.0.1) is too low for project ':react-native-mixpanel'. Minimum required is 25.0.0